### PR TITLE
Encode project_id in header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,6 +13,7 @@ var protocol = require('segmentio/protocol');
 var send = require('yields/send-json');
 var topDomain = require('top-domain');
 var uuid = require('uuid');
+var encode = require('ForbesLindesay/base64-encode');
 
 /**
  * Cookie options
@@ -166,9 +167,20 @@ Attribution.prototype.normalize = function(msg) {
  */
 
 Attribution.prototype.send = function(path, msg, fn) {
-  var projectId = this.options.project || window.Attribution.projectId;
-  var url = scheme() + '//track.attributionapp.com' + path + "?project_id=" + projectId;
-  var headers = { 'Content-Type': 'text/plain' };
+  var url = scheme() + '//track.attributionapp.com' + path;
+
+  var username = this.options.project || window.Attribution.projectId;
+  var password = "";
+  var basicAuth = 'Basic ' + encode(username + ":" + password);
+
+  var headers = {
+    'Content-Type': 'text/plain',
+    'Authorization': basicAuth
+  };
+
+  // No headers on JSONP so put the project_id in the msg
+  msg.project_id = username;
+
   fn = fn || noop;
   var self = this;
 


### PR DESCRIPTION
@anark This moves the project_id param into the header to be more like our segment integration.

For JSONP, because you can't add headers, it puts the project_id in the data (which is then cerealized into the params).