### PR TITLE
Filter out GTM app spot requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,8 +168,10 @@ Attribution.prototype.normalize = function(msg) {
  */
 
 Attribution.prototype.send = function(path, msg, fn) {
-  var url = scheme() + '//track.attributionapp.com' + path;
+  // If sending from GTM appspot IFrame, don't send
+  if(global.location.href.search('gtm-msr.appspot.com') !== -1) return;
 
+  var url = scheme() + '//track.attributionapp.com' + path;
   var projectId = this.options.project || window.Attribution.projectId;
 
   // If we're POSTing, let's send the project_id in the params


### PR DESCRIPTION
@anark what do you think of filtering out GTM iFrame requests like this?

I think we need to filter them somewhere, several users have had this problem.

I'm not sure if it makes sense to do here or on the tracking API. If we did it on the tracking api, I'm not even really sure how we would do it b/c the Track events don't have urls associated with them when we get them.
